### PR TITLE
fix: improve rewards traceability and DOR API reliability

### DIFF
--- a/metagraph/modules/l0/src/main/scala/com/my/dor_metagraph/l0/rewards/bounties/AnalyticsBountyRewards.scala
+++ b/metagraph/modules/l0/src/main/scala/com/my/dor_metagraph/l0/rewards/bounties/AnalyticsBountyRewards.scala
@@ -27,10 +27,13 @@ class AnalyticsBountyRewards[F[_] : Async] extends BountyRewards {
       acc            : RewardTransactionsInformation,
       deviceInfo     : DeviceInfo,
       devicesBalances: Map[Address, Balance]
-    ): F[RewardTransactionsInformation] =
+    ): F[RewardTransactionsInformation] = {
+      val publicId = deviceInfo.publicId.getOrElse("unknown")
+      val teamId = deviceInfo.analyticsBountyInformation.map(_.teamId).getOrElse(UndefinedTeamId)
+
       deviceInfo.analyticsBountyInformation.get.analyticsRewardAddress match {
         case None =>
-          logger.warn(s"Device doesn't have rewardAddress").as(acc)
+          logger.warn(s"[ANALYTICS] Device [publicId=$publicId, teamId=$teamId] doesn't have rewardAddress").as(acc)
 
         case Some(analyticsRewardAddress) =>
           for {
@@ -41,11 +44,14 @@ class AnalyticsBountyRewards[F[_] : Async] extends BountyRewards {
             deviceTaxToValidatorNodes = (deviceTotalRewards * ValidatorNodeTaxRate).toLong
             rewardValue = deviceTotalRewards - deviceTaxToValidatorNodes
 
+            _ <- logger.info(s"[ANALYTICS] Team representative device [publicId=$publicId, teamId=$teamId, rewardAddress=${analyticsRewardAddress.value.value}] reward=$rewardValue validatorTax=$deviceTaxToValidatorNodes collateralMultiplier=$collateralMultiplierFactor")
+
             deviceReward = buildDeviceReward(rewardValue, acc.rewardTransactions, analyticsRewardAddress)
             taxesToValidatorNodesUpdated = acc.validatorsTaxes + deviceTaxToValidatorNodes
 
           } yield RewardTransactionsInformation(deviceReward, taxesToValidatorNodesUpdated, updatedBalances)
       }
+    }
 
     for {
       _ <- logInitialRewardDistribution(currentEpochProgress)
@@ -65,8 +71,9 @@ class AnalyticsBountyRewards[F[_] : Async] extends BountyRewards {
           } else {
             val device: DeviceInfo = teamDevices.head
             val analyticsBountyInformation = device.analyticsBountyInformation.get
+            val devicePublicIds = teamDevices.flatMap(_.publicId).toList
             analyticsBountyInformation.analyticsRewardAddress match {
-              case None => logger.warn(s"Team ${analyticsBountyInformation.teamId} doesn't have default rewardAddress, skipping Analytics rewards.").as(acc)
+              case None => logger.warn(s"[ANALYTICS] Team ${analyticsBountyInformation.teamId} doesn't have default rewardAddress, skipping Analytics rewards. Affected devices=${teamDevices.size}, publicIds=${devicePublicIds.mkString(",")}").as(acc)
               case Some(analyticsRewardAddress) =>
                 val teamId = analyticsBountyInformation.teamId
                 val devicesCollateralAverage = getDevicesCollateralAverage(teamDevices, acc.lastBalances)
@@ -74,6 +81,7 @@ class AnalyticsBountyRewards[F[_] : Async] extends BountyRewards {
 
                 for {
                   _ <- logger.info(s"[teamId: $teamId] Devices number: ${teamDevices.size}")
+                  _ <- logger.info(s"[teamId: $teamId] Device publicIds: ${devicePublicIds.mkString(",")}")
                   _ <- logger.info(s"[teamId: $teamId] Collateral average: $devicesCollateralAverage")
                   _ <- logger.info(s"[teamId: $teamId] Address to be rewarded: $analyticsRewardAddress")
                   rewardTransactionsInformation <- combine(acc, device, newBalancesWithAverage)

--- a/metagraph/modules/l0/src/main/scala/com/my/dor_metagraph/l0/rewards/bounties/DailyBountyRewards.scala
+++ b/metagraph/modules/l0/src/main/scala/com/my/dor_metagraph/l0/rewards/bounties/DailyBountyRewards.scala
@@ -25,13 +25,16 @@ class DailyBountyRewards[F[_] : Async] extends BountyRewards {
     def noCheckInMade(nextEpochProgressToReward: Long): Boolean =
       currentEpochProgress - nextEpochProgressToReward >= EpochProgress1Day
 
-    def combine(acc: RewardTransactionsInformation, deviceInfo: DeviceInfo): F[RewardTransactionsInformation] =
+    def combine(acc: RewardTransactionsInformation, entry: (Address, DeviceInfo)): F[RewardTransactionsInformation] = {
+      val (deviceAddress, deviceInfo) = entry
+      val publicId = deviceInfo.publicId.getOrElse("unknown")
+
       deviceInfo.dorAPIResponse.rewardAddress match {
         case None =>
-          logger.warn(s"Device doesn't have rewardAddress").as(acc)
+          logger.warn(s"[DAILY] Device [address=${deviceAddress.value.value}, publicId=$publicId] doesn't have rewardAddress").as(acc)
 
         case Some(rewardAddress) if noCheckInMade(deviceInfo.nextEpochProgressToReward) =>
-          logger.warn(s"Device with reward address ${rewardAddress.value.value} didn't make a check in the last 24 hours").as(acc)
+          logger.warn(s"[DAILY] Device [address=${deviceAddress.value.value}, publicId=$publicId, rewardAddress=${rewardAddress.value.value}] didn't make a check in the last 24 hours").as(acc)
 
         case Some(rewardAddress) =>
           for {
@@ -42,15 +45,18 @@ class DailyBountyRewards[F[_] : Async] extends BountyRewards {
             deviceTaxToValidatorNodes = (deviceTotalRewards * ValidatorNodeTaxRate).toLong
             rewardValue = deviceTotalRewards - deviceTaxToValidatorNodes
 
+            _ <- logger.info(s"[DAILY] Device [address=${deviceAddress.value.value}, publicId=$publicId, rewardAddress=${rewardAddress.value.value}] reward=$rewardValue validatorTax=$deviceTaxToValidatorNodes collateralMultiplier=$collateralMultiplierFactor")
+
             deviceReward = buildDeviceReward(rewardValue, acc.rewardTransactions, rewardAddress)
             taxesToValidatorNodesUpdated = acc.validatorsTaxes + deviceTaxToValidatorNodes
 
           } yield RewardTransactionsInformation(deviceReward, taxesToValidatorNodesUpdated, updatedBalances)
       }
+    }
 
     for {
       _ <- logInitialRewardDistribution(currentEpochProgress)
-      bountyRewards <- state.devices.values.toList
+      bountyRewards <- state.devices.toList
         .foldLeftM(RewardTransactionsInformation(Map.empty, 0L, lastBalancesRaw))(combine)
         .map(reward => RewardTransactionsAndValidatorsTaxes(reward.rewardTransactions.values.toList, reward.validatorsTaxes))
       _ <- logAllDevicesRewards(bountyRewards)

--- a/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/LifecycleSharedFunctions.scala
+++ b/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/LifecycleSharedFunctions.scala
@@ -45,17 +45,19 @@ object LifecycleSharedFunctions {
     if (updates.isEmpty) {
       logger.info("Snapshot without any check-ins, updating the state to empty updates").as(newState)
     } else {
-      updates.foldLeftM(newState) { (acc, signedUpdate) =>
-        for {
-          epochProgress <- context.getLastCurrencySnapshot.flatMap {
-            case Some(value) => value.epochProgress.pure[F]
-            case None =>
-              val message = "Could not get the epochProgress from currency snapshot. lastCurrencySnapshot not found"
-              logger.error(message) >> new Exception(message).raiseError[F, EpochProgress]
-          }
-          address <- getFirstAddressFromProofs(signedUpdate.proofs)
-        } yield combineDeviceCheckIn(acc, signedUpdate, address, epochProgress.next)
-      }
+      for {
+        epochProgress <- context.getLastCurrencySnapshot.flatMap {
+          case Some(value) => value.epochProgress.pure[F]
+          case None =>
+            val message = "Could not get the epochProgress from currency snapshot. lastCurrencySnapshot not found"
+            logger.error(message) >> new Exception(message).raiseError[F, EpochProgress]
+        }
+        nextEpoch = epochProgress.next
+        result <- updates.foldLeftM(newState) { (acc, signedUpdate) =>
+          getFirstAddressFromProofs(signedUpdate.proofs)
+            .map(address => combineDeviceCheckIn(acc, signedUpdate, address, nextEpoch))
+        }
+      } yield result
     }
   }
 }

--- a/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/Utils.scala
+++ b/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/Utils.scala
@@ -32,6 +32,10 @@ object Utils {
   def getByteArrayFromRequestBody(
     bodyAsString: String
   ): Array[Byte] = {
+    if ((bodyAsString.length & 1) != 0) {
+      throw new IllegalArgumentException(s"Request body has odd length ${bodyAsString.length}; expected hex-encoded bytes")
+    }
+
     val bodyAsBytes: ListBuffer[Byte] = ListBuffer.empty
 
     var idx = 0
@@ -84,10 +88,12 @@ object Utils {
     SortedSet.from(summedTransactions)
   }
 
+  val DatolitesPerDag: Double = 1e8
+
   def toTokenAmountFormat(
     balance: Double
   ): Long = {
-    (balance * 10e7).toLong
+    (balance * DatolitesPerDag).toLong
   }
 
   def getDeviceCheckInInfo[F[_] : Async](
@@ -99,9 +105,7 @@ object Utils {
         logger.error(message) >> new Exception(message).raiseError[F, Array[Byte]]
       }
       decodedCheckIn = Cbor.decode(checkInCborData).to[DeviceCheckInInfo].value
-      _ <- logger.info(s"Decoded check-in AC: ${decodedCheckIn.ac}")
-      _ <- logger.info(s"Decoded check-in DTS: ${decodedCheckIn.dts}")
-      _ <- logger.info(s"Decoded check-in E: ${decodedCheckIn.e}")
+      _ <- logger.debug(s"Decoded check-in dts=${decodedCheckIn.dts}")
     } yield decodedCheckIn
   }
 

--- a/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/combiners/DeviceCheckIn.scala
+++ b/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/combiners/DeviceCheckIn.scala
@@ -1,5 +1,6 @@
 package com.my.dor_metagraph.shared_data.combiners
 
+import cats.syntax.option._
 import com.my.dor_metagraph.shared_data.types.Types._
 import io.constellationnetwork.currency.dataApplication.DataState
 import io.constellationnetwork.schema.address.Address
@@ -21,7 +22,7 @@ object DeviceCheckIn {
     val checkInProof = CheckInProof(checkInUpdate.publicId, checkInUpdate.signature)
     val checkInStateUpdate = CheckInStateUpdate(address, checkInUpdate.dts, checkInProof, checkInUpdate.dtmCheckInHash)
 
-    val checkIn = DeviceInfo(checkInUpdate.dts, dorAPIResponse, nextRewardEpochProgress, maybeAnalyticsBountyInformation)
+    val checkIn = DeviceInfo(checkInUpdate.dts, dorAPIResponse, nextRewardEpochProgress, maybeAnalyticsBountyInformation, checkInUpdate.publicId.some)
 
     val devices: Map[Address, DeviceInfo] = acc.calculated.devices.updated(address, checkIn)
     val updates: List[CheckInStateUpdate] = checkInStateUpdate :: acc.onChain.updates
@@ -56,26 +57,28 @@ object DeviceCheckIn {
     maybeDeviceInfo: Option[DeviceInfo],
     dorAPIResponse : DorAPIResponse
   ): Option[AnalyticsBountyInformation] =
-    dorAPIResponse
-      .lastBillingId
-      .map { lastBillingId =>
-        maybeDeviceInfo
-          .flatMap(_.analyticsBountyInformation)
-          .map(updateAnalyticsBountyInformation(epochProgress, dorAPIResponse, lastBillingId, _))
-          .getOrElse(createAnalyticsBountyInformation(epochProgress, dorAPIResponse))
-      }
+    dorAPIResponse.lastBillingId.flatMap { lastBillingId =>
+      maybeDeviceInfo
+        .flatMap(_.analyticsBountyInformation)
+        .map(old => updateAnalyticsBountyInformation(epochProgress, dorAPIResponse, lastBillingId, old).some)
+        .getOrElse(createAnalyticsBountyInformation(epochProgress, dorAPIResponse))
+    }
 
   private def createAnalyticsBountyInformation(
     epochProgress : EpochProgress,
     dorAPIResponse: DorAPIResponse
-  ): AnalyticsBountyInformation = {
+  ): Option[AnalyticsBountyInformation] = {
     val (_, nextRewardEpoch: Long) = getRewardEpoch(epochProgress)
 
-    AnalyticsBountyInformation(
+    for {
+      teamId        <- dorAPIResponse.teamId
+      lastBillingId <- dorAPIResponse.lastBillingId
+      billedAmount  <- dorAPIResponse.billedAmount
+    } yield AnalyticsBountyInformation(
       nextRewardEpoch + ModulusAnalyticsBounty,
-      dorAPIResponse.teamId.get,
-      dorAPIResponse.lastBillingId.get,
-      dorAPIResponse.billedAmount.get,
+      teamId,
+      lastBillingId,
+      billedAmount,
       dorAPIResponse.orgRewardAddress,
     )
   }
@@ -89,7 +92,7 @@ object DeviceCheckIn {
     if (oldAnalyticsBountyInformation.lastBillingId == lastBillingId || oldAnalyticsBountyInformation.nextEpochProgressToRewardAnalytics > epochProgress.value.value) {
       oldAnalyticsBountyInformation
     } else {
-      createAnalyticsBountyInformation(epochProgress, dorAPIResponse)
+      createAnalyticsBountyInformation(epochProgress, dorAPIResponse).getOrElse(oldAnalyticsBountyInformation)
     }
   }
 }

--- a/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/decoders/Decoders.scala
+++ b/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/decoders/Decoders.scala
@@ -33,12 +33,9 @@ object Decoders {
     val proofs = NonEmptySet.fromSetUnsafe(SortedSet(signatureProof))
 
     for {
-      _ <- logger.info(s"Decoded CBOR field ${decodedCheckInWithSignature.cbor}")
-      _ <- logger.info(s"Decoded HASH field ${decodedCheckInWithSignature.hash}")
-      _ <- logger.info(s"Decoded ID field ${decodedCheckInWithSignature.id}")
-      _ <- logger.info(s"Decoded SIGNATURE field ${decodedCheckInWithSignature.sig}")
-      maybeDeviceCheckInDORApi <- handleCheckInDorApi(decodedCheckInWithSignature.id, decodedCheckInWithSignature)
+      _ <- logger.debug(s"Decoded check-in for id=${decodedCheckInWithSignature.id}")
       checkInInfo <- getDeviceCheckInInfo(decodedCheckInWithSignature.cbor)
+      maybeDeviceCheckInDORApi <- handleCheckInDorApi(decodedCheckInWithSignature.id, decodedCheckInWithSignature, checkInInfo)
 
       checkInUpdate = CheckInUpdate(
         decodedCheckInWithSignature.id,
@@ -55,7 +52,6 @@ object Decoders {
     EntityDecoder.decodeBy(MediaType.text.plain) { msg =>
       val rawText = msg.as[String]
       val signed = rawText.flatMap { text =>
-        logger.info(s"Received RAW request: $text")
         val bodyAsBytes = getByteArrayFromRequestBody(text)
         buildSignedUpdate(bodyAsBytes)
       }

--- a/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/external_apis/ClusterApi.scala
+++ b/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/external_apis/ClusterApi.scala
@@ -14,12 +14,16 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 object ClusterApi {
   def logger[F[_] : Async]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("ClusterApi")
 
+  private val ConnectTimeoutMs: Int = 5_000
+  private val ReadTimeoutMs: Int = 10_000
+
   private def getValidatorNodesAddressesFromClusterInfo[F[_] : Async : SecurityProvider](
     url: String
   ): F[List[Address]] = {
     for {
-      response <- Async[F].delay(requests.get(url))
-      body = response.text()
+      body <- Async[F].blocking(
+        requests.get(url, readTimeout = ReadTimeoutMs, connectTimeout = ConnectTimeoutMs).text()
+      )
       _ <- logger.info(s"API ($url) response $body")
       clusterInfo <- Async[F].fromEither(decode[List[ClusterInfoResponse]](body))
       decoded <- clusterInfo.traverse(nodeInfo => getDagAddressFromPublicKey(nodeInfo.id))

--- a/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/external_apis/DorApi.scala
+++ b/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/external_apis/DorApi.scala
@@ -6,28 +6,32 @@ import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
-import com.my.dor_metagraph.shared_data.Utils.{getDeviceCheckInInfo, getEnv}
-import com.my.dor_metagraph.shared_data.types.Types.{DeviceCheckInWithSignature, DorAPIResponse}
+import com.my.dor_metagraph.shared_data.Utils.getEnv
+import com.my.dor_metagraph.shared_data.types.Types.{DeviceCheckInInfo, DeviceCheckInWithSignature, DorAPIResponse}
 import io.circe.parser.decode
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import ujson.Obj
 
+import scala.concurrent.duration._
+
 object DorApi {
   def logger[F[_] : Async]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLoggerFromName[F]("DorApi")
 
+  private val ConnectTimeoutMs: Int = 5_000
+  private val ReadTimeoutMs: Int = 10_000
+  private val MaxRetries: Int = 3
+  private val InitialBackoff: FiniteDuration = 200.millis
+
   private def saveDeviceCheckIn[F[_] : Async: Env](
-    publicKey    : String,
-    deviceCheckIn: DeviceCheckInWithSignature
+    publicKey      : String,
+    deviceCheckIn  : DeviceCheckInWithSignature,
+    checkInInfo    : DeviceCheckInInfo
   ): F[Option[DorAPIResponse]] = {
     for {
       apiUrl <- getEnv[F]("DOR_API_URL")
       endpoint = s"$apiUrl/$publicKey/check-in"
       headers = Map("Content-Type" -> "application/json", "version" -> "2")
-      checkInInfo <- getDeviceCheckInInfo(deviceCheckIn.cbor)
-      _ <- logger.info(s"Decoded CBOR field before check-in to DOR Server AC ${checkInInfo.ac}")
-      _ <- logger.info(s"Decoded CBOR field before check-in to DOR Server DTS ${checkInInfo.dts}")
-      _ <- logger.info(s"Decoded CBOR field before check-in to DOR Server E ${checkInInfo.e}")
 
       requestBody = Obj(
         "ac" -> checkInInfo.ac,
@@ -37,29 +41,48 @@ object DorApi {
         "signature" -> deviceCheckIn.sig
       ).render()
 
-      _ <- logger.info(s"Request body: $requestBody")
+      _ <- logger.debug(s"Posting check-in to DOR for $publicKey")
 
-      body = requests.post(
-        url = endpoint,
-        headers = headers,
-        data = requestBody
-      ).text()
+      body <- Async[F].blocking(
+        requests.post(
+          url = endpoint,
+          headers = headers,
+          data = requestBody,
+          readTimeout = ReadTimeoutMs,
+          connectTimeout = ConnectTimeoutMs
+        ).text()
+      )
 
-      _ <- logger.info(s"API response $body")
+      _ <- logger.debug(s"DOR API response for $publicKey: $body")
 
       decodedResponse <- decode[DorAPIResponse](body).fold(
-        err => logger.warn(s"Failing when decoding: ${err.getMessage}").as(none),
+        err => logger.warn(s"Failing when decoding DOR response for $publicKey: ${err.getMessage}").as(none[DorAPIResponse]),
         response => Async[F].pure(response.some)
       )
     } yield decodedResponse
   }
 
+  private def retrying[F[_] : Async, A](
+    publicKey  : String,
+    attempt    : Int,
+    backoff    : FiniteDuration,
+    action     : F[A]
+  ): F[A] =
+    action.handleErrorWith { err =>
+      if (attempt >= MaxRetries) {
+        logger.warn(s"DOR API call for $publicKey failed after $MaxRetries attempts: ${err.getMessage}") >>
+          err.raiseError[F, A]
+      } else {
+        logger.warn(s"DOR API call for $publicKey failed on attempt $attempt: ${err.getMessage}. Retrying in $backoff") >>
+          Async[F].sleep(backoff) >>
+          retrying(publicKey, attempt + 1, backoff * 2, action)
+      }
+    }
+
   def handleCheckInDorApi[F[_] : Async: Env](
     publicKey    : String,
-    deviceCheckIn: DeviceCheckInWithSignature
-  ): F[Option[DorAPIResponse]] = {
-    saveDeviceCheckIn(publicKey, deviceCheckIn).handleErrorWith { err =>
-      logger.warn(s"Failing when check in: ${err.getMessage}").as(none)
-    }
-  }
+    deviceCheckIn: DeviceCheckInWithSignature,
+    checkInInfo  : DeviceCheckInInfo
+  ): F[Option[DorAPIResponse]] =
+    retrying(publicKey, attempt = 1, backoff = InitialBackoff, saveDeviceCheckIn(publicKey, deviceCheckIn, checkInInfo))
 }

--- a/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/types/Types.scala
+++ b/metagraph/modules/shared_data/src/main/scala/com/my/dor_metagraph/shared_data/types/Types.scala
@@ -50,7 +50,8 @@ object Types {
     lastCheckIn               : Long,
     dorAPIResponse            : DorAPIResponse,
     nextEpochProgressToReward : Long,
-    analyticsBountyInformation: Option[AnalyticsBountyInformation]
+    analyticsBountyInformation: Option[AnalyticsBountyInformation],
+    publicId                  : Option[String] = None
   )
 
   @derive(encoder, decoder)


### PR DESCRIPTION
## Summary

Targets the "users not receiving rewards" reports. Two related problems:

1. **Reward logs were untraceable** — `Device doesn't have rewardAddress` and `Device with reward address X didn't make a check-in in 24h` were impossible to debug because they didn't identify the device.
2. **DOR API failures silently dropped check-ins** — `handleCheckInDorApi` caught every exception and returned `None`, which validation then rejected as `DeviceNotRegisteredOnDorApi`. A DOR API blip → device's check-in is silently lost → 24h later "no check-in, no reward".

## Changes

### Logging traceability
- Added `publicId: Option[String] = None` to `DeviceInfo` (defaulted for backward compat with persisted state).
- `combineDeviceCheckIn` now populates it on every check-in.
- `DailyBountyRewards` / `AnalyticsBountyRewards` log lines now include device on-chain address + publicId in every WARN and per-device INFO.

### DOR API reliability
- `handleCheckInDorApi` retries with exponential backoff (3 attempts: 200/400/800ms). On exhaustion it **raises** instead of returning `None`. Device receives 5xx and retries on its own cadence.
- `requests.post` / `requests.get` now wrapped in `Async[F].blocking` with explicit `connectTimeout=5s`, `readTimeout=10s`. Threads can no longer be pinned indefinitely.

### Correctness / hardening
- `createAnalyticsBountyInformation` uses for-comprehension over `teamId`/`lastBillingId`/`billedAmount` instead of `.get` — partial DOR responses no longer crash the combine batch.
- `getByteArrayFromRequestBody` rejects odd-length input with a clear error instead of throwing `StringIndexOutOfBoundsException` mid-loop.

### Performance
- CBOR decoded once per request (was 3×) — threaded `DeviceCheckInInfo` through `handleCheckInDorApi`.
- `getLastCurrencySnapshot` lifted out of the `combine` fold — one fetch per batch instead of per update.
- Per-request decode/HTTP body INFO logs demoted to DEBUG. Critical at thousands of req/min.

### Cleanup
- Replaced `10e7` magic value with named `DatolitesPerDag = 1e8` constant.

## Risk assessment

**Low risk:**
- Blocking-wrap + timeouts, CBOR dedup, `.get` guards, odd-length validation, `10e7` rename, lifting `getLastCurrencySnapshot`, log-level demotion.

**Behavior change (verify before merging to mainnet):**
- DOR API failure now produces 5xx instead of silent drop. **Device firmware must retry on 5xx** — please confirm with the device team.
- `DeviceInfo` gains a new field — `CheckInDataCalculatedState` schema changes. Circe Magnolia should decode missing field as `None` via the default, but a round-trip serialization test against existing snapshot JSON is recommended before mainnet rollout.
- All L0 consensus nodes must upgrade together to avoid state-hash divergence (the new `publicId` field is part of the calculated state).

**Picked timeout values** (5s connect / 10s read) — please confirm these are above DOR API p99 latency before rollout.

## Test plan

- [x] `sbt sharedData/test currencyL0/test` — 19/19 pass
- [x] Full `sbt test` — passes
- [ ] Backward-compatible deserialization of existing calculated state (recommend adding a fixture-based round-trip test before mainnet)
- [ ] Confirm device client retries on 5xx response from L1 check-in endpoint
- [ ] Verify 10s read timeout is above DOR API p99 latency in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)